### PR TITLE
Fixes append_path.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -683,7 +683,7 @@ impl Context {
 
     pub fn append_path(&self, path: &Path){
         unsafe {
-            ffi::cairo_append_path(self.get_ptr(), transmute(path))
+            ffi::cairo_append_path(self.get_ptr(), transmute(path.get_ptr()))
         }
     }
 


### PR DESCRIPTION
This fixes the bug where upon appending a path GTK complains and the context no longer works: "Gtk-WARNING **: drawing failure for widget `GtkDrawingArea': invalid value for an input cairo_status_t"