### PR TITLE
Remove features from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ keywords = ["cairo", "gtk", "gnome", "GUI"]
 [lib]
 name = "cairo"
 
-[features]
-cairo_1_10 = []
-cairo_1_12 = []
-
 [dependencies.cairo-sys-rs]
 path = "./cairo-sys-rs"
 


### PR DESCRIPTION
The build scripts already detect the library version automatically.